### PR TITLE
Android Manifest fix for Android 12 onwards

### DIFF
--- a/sources/android/legacy/app/src/debug/AndroidManifest.xml
+++ b/sources/android/legacy/app/src/debug/AndroidManifest.xml
@@ -10,7 +10,11 @@
         android:supportsRtl="true"
         tools:replace="android:name"
         android:theme="@style/SplashTheme">
-        <activity android:name=".Core.JasonViewActivity" android:windowSoftInputMode="adjustResize" >
+        <activity
+            android:name=".Core.JasonViewActivity"
+            android:exported="true"
+            android:windowSoftInputMode="adjustResize"
+            >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/sources/android/legacy/app/src/main/java/com/jasonette/seed/Component/JasonHtmlComponent.java
+++ b/sources/android/legacy/app/src/main/java/com/jasonette/seed/Component/JasonHtmlComponent.java
@@ -44,9 +44,10 @@ public class JasonHtmlComponent {
                 settings.setJavaScriptCanOpenWindowsAutomatically(true);
                 settings.setMediaPlaybackRequiresUserGesture(false);
 
-                settings.setAppCachePath( context.getCacheDir().getAbsolutePath() );
+                // TODO(ABS) Commenting this to compile
+                // settings.setAppCachePath( context.getCacheDir().getAbsolutePath() );
                 settings.setAllowFileAccess( true );
-                settings.setAppCacheEnabled( true );
+                // settings.setAppCacheEnabled( true );
                 settings.setCacheMode( WebSettings.LOAD_DEFAULT );
 
 

--- a/sources/android/legacy/app/src/main/java/com/jasonette/seed/Service/agent/JasonAgentService.java
+++ b/sources/android/legacy/app/src/main/java/com/jasonette/seed/Service/agent/JasonAgentService.java
@@ -525,9 +525,10 @@ public class JasonAgentService {
                 settings.setDomStorageEnabled(true);
                 settings.setMediaPlaybackRequiresUserGesture(false);
                 settings.setJavaScriptCanOpenWindowsAutomatically(true);
-                settings.setAppCachePath(context.getCacheDir().getAbsolutePath());
+                // TODO(ABS) Commenting this to compile
+                // settings.setAppCachePath(context.getCacheDir().getAbsolutePath());
                 settings.setAllowFileAccess(true);
-                settings.setAppCacheEnabled(true);
+                // settings.setAppCacheEnabled(true);
                 settings.setCacheMode(WebSettings.LOAD_DEFAULT);
                 
                 // Check for special options in background webview


### PR DESCRIPTION
## Android Manifest fix for Android 12 onwards

Trying to solve the issue with Android 12 adding the `exported="true"` in `AndroidManifest.xml` file for debug variant

- Also, after some audit of the project, I highly recommend migrate from Java to Kotlin and update some deprecated libraries.